### PR TITLE
remove email from track calls

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -41,8 +41,7 @@ exports.track = function(track){
     event_name: track.event(),
     data: track.properties(),
     identity: {
-      id: track.userId(),
-      email: track.email()
+      id: track.userId()
     },
     extras: {
       created_at: time(track.timestamp()),

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -23,8 +23,7 @@
       "source": "segment"
     },
     "identity": {
-      "id": "user-id",
-      "email": "jd@example.com"
+      "id": "user-id"
     },
     "data": {
       "avatar": "avatar.jpg",

--- a/test/index.js
+++ b/test/index.js
@@ -90,8 +90,7 @@ describe('Vero', function(){
           event_name: track.event(),
           data: track.properties(),
           identity: {
-            id: track.userId(),
-            email: track.email()
+            id: track.userId()
           },
           extras: {
             created_at: time(track.timestamp()),


### PR DESCRIPTION
Talked to Chris, Co-Founder at Vero and he agreed that we need not pass the `email` trait inside the `identity` block for a `.track()` call. This eliminates a small edge case when user sends an email inside our `track.properties` that does not belong to the user triggering the event.

Ref: https://www.getvero.com/api/http/#actions

@ndhoule @sperand-io 